### PR TITLE
Dragdrop

### DIFF
--- a/battletracker/battletracker_unitsummary.xml
+++ b/battletracker/battletracker_unitsummary.xml
@@ -96,6 +96,7 @@
 				<anchored to="size" position="belowleft" offset="0,7" width="25" />
 				<target>attack</target>
 				<defense>defense</defense>
+				<rollable />
 			</number_bt_unitstat>
 			<label name="power_label">
 				<anchored to="casualties_label" position="belowleft" offset="0,5" />
@@ -105,6 +106,7 @@
 				<anchored to="casualties" position="belowleft" offset="0,7" width="25" />
 				<target>power</target>
 				<defense>toughness</defense>
+				<rollable />
 			</number_bt_unitstat>
 			<label name="morale_label">
 				<anchored to="defense_label" position="belowleft" offset="0,5" />
@@ -113,6 +115,7 @@
 			<number_bt_unitstat name="morale" source="abilities.morale">
 				<anchored to="defense" position="belowleft" offset="0,7" width="25" />
 				<target>morale</target>
+				<rollable />
 			</number_bt_unitstat>
 			<label name="command_label">
 				<anchored to="toughness_label" position="belowleft" offset="0,5" />
@@ -121,6 +124,7 @@
 			<number_bt_unitstat name="command" source="abilities.command">
 				<anchored to="toughness" position="belowleft" offset="0,7" width="25" />
 				<target>command</target>
+				<rollable />
 			</number_bt_unitstat>
 
 			<label name="number_attacks_label">
@@ -136,6 +140,8 @@
 			</label>
 			<number_ct name="damage" source="damage">
 				<anchored to="power" position="belowleft" offset="0,7" />
+				<script file="common/scripts/number_unitdamage.lua" />
+				<rollable />
 			</number_ct>
 			<label name="reaction_label">
 				<anchored to="morale_label" position="belowleft" offset="0,7" />

--- a/campaign/record_unit.xml
+++ b/campaign/record_unit.xml
@@ -340,9 +340,11 @@
                 <static textres="unit_label_damage" />
             </label_column_right>
             <number_column_right name="damage">
+				<script file="common/scripts/number_unitdamage.lua" />
 				<anchored to="attacks" />
                 <default>1</default>
                 <min>1</min>
+				<rollable />
             </number_column_right>
 
 			<line_column />

--- a/common/scripts/number_unitdamage.lua
+++ b/common/scripts/number_unitdamage.lua
@@ -1,0 +1,29 @@
+-- 
+-- Please see the license.html file included with this distribution for 
+-- attribution and copyright information.
+--
+
+function action(draginfo)
+	CombatManagerKw.pushListMode(CombatManagerKw.LIST_MODE_UNIT);
+	local rActor = ActorManager.resolveActor(window.getDatabaseNode());
+	local rAction = {};
+	rAction.label = "Power";
+	rAction.clauses = {}
+
+	local clause = {};
+	clause.dice = { };
+	clause.modifier = getValue();
+	clause.dmgtype = (ActorManagerKw.getUnitType(rActor) or ""):lower();
+	table.insert(rAction.clauses, clause);					
+
+	ActionDamage.performRoll(draginfo, rActor, rAction);
+	CombatManagerKw.popListMode();
+	return true;
+end
+function onDragStart(button, x, y, draginfo)
+	return action(draginfo);
+end
+	
+function onDoubleClick(x, y)
+	return action();
+end

--- a/scripts/kw.lua
+++ b/scripts/kw.lua
@@ -135,7 +135,7 @@ function onInit()
 	fOnModuleLoad = Module.onModuleLoad;
 	Module.onModuleLoad = onModuleLoad;
 
-	GameSystem.actions.test = { bUseModStack = true, sTargeting = "each" };
+	GameSystem.actions.test = { sIcon = "action_attack", bUseModStack = true, sTargeting = "each" };
 	GameSystem.actions.rally = { bUseModStack = true };
 	GameSystem.actions.powerdie = { bUseModStack = false, sTargeting = "all" };
 	GameSystem.actions.domainskill = { bUseModStack = true };

--- a/scripts/manager_action_test.lua
+++ b/scripts/manager_action_test.lua
@@ -474,6 +474,11 @@ function onTest(rSource, rTarget, rRoll)
 		if rRoll.nTarget then
 			notifyApplyTest(rSource, rTarget, false, sModStat, rRoll.sDesc, rAction.nTotal, tonumber(rRoll.nTarget), table.concat(rAction.aMessages, " "));
 		end
+
+		-- if this is an attack test with no target, then simply print out a damage roll.
+		if sModStat == "attack" then
+			handleDamage(rSource, nil, false, sModStat, 1);
+		end
 	end
 end
 

--- a/scripts/manager_actor_kw.lua
+++ b/scripts/manager_actor_kw.lua
@@ -127,12 +127,15 @@ function getAbilityBonus(rUnit, sAbility)
 	return nAbilityScore;
 end
 
-function getDefenseValue(rAttacker, rDefender, rRoll)
+function getDefenseValue(rAttacker, rDefender, rRoll, sDef)
 	if not rDefender or not rRoll then
 		return nil, 0, 0, false, false;
 	end
 
-	local sDef = rRoll.sDesc:match("%[DEF:(%w+)%]");
+	if not sDef then
+		sDef = rRoll.sDesc:match("%[DEF:(%w+)%]");
+	end
+
 	if not sDef then
 		return nil, 0, 0, false, false;
 	end


### PR DESCRIPTION
Attack test that lack a target will always follow up the attack roll with a damage roll for 1 damage. This allows for drag/dropping the damage after the fact (since it doesn't work too well with the attack test).

Changed the damage field on the unit sheet and summary card to roll damage.

Updated the unit summary card so that fields that are rollable have the roll icon.